### PR TITLE
Add grpcio-tools to the tts/requirements.txt file

### DIFF
--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -1,3 +1,4 @@
 absl-py==0.12.0
 grpcio==1.37.1
 protobuf==3.19.5
+grpcio-tools


### PR DESCRIPTION
To build stub files from protobuf files, grpcio-tools package is required.

Changes:
- Added grpcio-tools to the requirements.txt file in the tts directory.